### PR TITLE
added python3.4-node6 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo "Containers"
 	@echo "===================================================================================================="
 	@echo "$(C_BG)python3.4:$(C_OFF)                              Python3.4 on ubuntu 14.04"
+	@echo "$(C_BG)python3.4-node6:$(C_OFF)                        Python3.4 on ubuntu 14.04 with nodejs 6.x"
 	@echo "$(C_BG)debian-python3.4:$(C_OFF)                       Python3.4 on debian jessie"
 	@echo "$(C_BG)alpine-python3.5:$(C_OFF)                       Python3.5 on alpine 3.4"
 	@echo "$(C_BG)postgres-9.4-et-ru:$(C_OFF)                     postgres:9.4 with extra locales"
@@ -39,8 +40,8 @@ help:
 	@echo "$(C_BG)make release-<container>$(C_OFF)                Build and publish <container>"
 
 
-build-all: build-python3.4 build-debian-python3.4 build-alpine-python3.5 build-postgres-9.4-et-ru build-drone-celery-alpine-3.5
-release-all: release-python3.4 release-debian-python3.4 release-alpine-python3.5 release-postgres-9.4-et-ru release-drone-celery-alpine-3.5
+build-all: build-python3.4 build-python3.4-node6 build-debian-python3.4 build-alpine-python3.5 build-postgres-9.4-et-ru build-drone-celery-alpine-3.5
+release-all: release-python3.4 release-python3.4-node6 release-debian-python3.4 release-alpine-python3.5 release-postgres-9.4-et-ru release-drone-celery-alpine-3.5
 
 
 release-python3.4:
@@ -48,6 +49,14 @@ ifeq ($(FAST),y)
 	cd python3.4 && $(MAKE) release-fast
 else
 	cd python3.4 && $(MAKE) release
+endif
+
+
+release-python3.4-node6:
+ifeq ($(FAST),y)
+	cd python3.4-node6 && $(MAKE) release-fast
+else
+	cd python3.4-node6 && $(MAKE) release
 endif
 
 
@@ -88,6 +97,14 @@ ifeq ($(FAST),y)
 	cd python3.4 && $(MAKE) build-fast
 else
 	cd python3.4 && $(MAKE) build
+endif
+
+
+build-python3.4-node6:
+ifeq ($(FAST),y)
+	cd python3.4-node6 && $(MAKE) build-fast
+else
+	cd python3.4-node6 && $(MAKE) build
 endif
 
 

--- a/python3.4-node6/Dockerfile
+++ b/python3.4-node6/Dockerfile
@@ -1,0 +1,8 @@
+FROM thorgate/python3.4
+
+MAINTAINER Thorgate, hi@thorgate.eu
+
+RUN echo "deb https://deb.nodesource.com/node_6.x trusty main" > /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb-src https://deb.nodesource.com/node_6.x trusty main" >> /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
+RUN apt-get install nodejs

--- a/python3.4-node6/Makefile
+++ b/python3.4-node6/Makefile
@@ -1,0 +1,23 @@
+.PHONY: release tag_latest build common
+
+NAME = thorgate/python3.4-node6
+VERSION = 1.0.0
+
+common:
+	yes | cp -rf ../common ./.common
+
+build: common
+	docker build -t $(NAME):$(VERSION) --rm .
+
+build-fast: common
+	docker build -t $(NAME):$(VERSION) .
+
+tag_latest:
+	docker tag -f $(NAME):$(VERSION) $(NAME):latest
+
+push:
+	@if ! docker images $(NAME) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME) version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	docker push $(NAME)
+
+release: build tag_latest push
+release-fast: build-fast tag_latest push

--- a/python3.4-node6/README.md
+++ b/python3.4-node6/README.md
@@ -1,0 +1,14 @@
+# python3.4
+
+- ubuntu 14.04
+- python3.4
+- pip
+- nodejs 6.x
+- phantomjs
+
+# Updating
+
+1. Update version in Makefile
+2. Update the Dockerfile
+3. `make build`
+4. `make release`


### PR DESCRIPTION
Right now Drone can't run React tests that use newer libraries. 

Forked python3.4 image to update node from 0.x to 6.x.
