### PR TITLE
Add python3.5-node6 image

### DIFF
--- a/alpine-python3.5/Makefile
+++ b/alpine-python3.5/Makefile
@@ -20,6 +20,9 @@ help:
 	@echo "$(C_BG)make tag_latest$(C_OFF)         Tag $(NAME):$(VERSION) as :latest"
 	@echo "$(C_BG)make push$(C_OFF)               Push $(NAME):$(VERSION) to docker registry"
 
+common:
+	yes | cp -rf ../common ./.common
+
 build: common
 ifdef REBUILD
 	@echo "REBUILDING $(NAME):$(VERSION)"

--- a/debian-python3.4/Makefile
+++ b/debian-python3.4/Makefile
@@ -20,6 +20,9 @@ help:
 	@echo "$(C_BG)make tag_latest$(C_OFF)         Tag $(NAME):$(VERSION) as :latest"
 	@echo "$(C_BG)make push$(C_OFF)               Push $(NAME):$(VERSION) to docker registry"
 
+common:
+	yes | cp -rf ../common ./.common
+
 build: common
 ifdef REBUILD
 	@echo "REBUILDING $(NAME):$(VERSION)"

--- a/drone-celery-alpine-3.5/Makefile
+++ b/drone-celery-alpine-3.5/Makefile
@@ -20,6 +20,9 @@ help:
 	@echo "$(C_BG)make tag_latest$(C_OFF)         Tag $(NAME):$(VERSION) as :latest"
 	@echo "$(C_BG)make push$(C_OFF)               Push $(NAME):$(VERSION) to docker registry"
 
+common:
+	yes | cp -rf ../common ./.common
+
 build: common
 ifdef REBUILD
 	@echo "REBUILDING $(NAME):$(VERSION)"

--- a/eveli/Makefile
+++ b/eveli/Makefile
@@ -20,6 +20,9 @@ help:
 	@echo "$(C_BG)make tag_latest$(C_OFF)         Tag $(NAME):$(VERSION) as :latest"
 	@echo "$(C_BG)make push$(C_OFF)               Push $(NAME):$(VERSION) to docker registry"
 
+common:
+	yes | cp -rf ../common ./.common
+
 build: common
 ifdef REBUILD
 	@echo "REBUILDING $(NAME):$(VERSION)"

--- a/postgres-9.4-et-ru/Makefile
+++ b/postgres-9.4-et-ru/Makefile
@@ -20,6 +20,9 @@ help:
 	@echo "$(C_BG)make tag_latest$(C_OFF)         Tag $(NAME):$(VERSION) as :latest"
 	@echo "$(C_BG)make push$(C_OFF)               Push $(NAME):$(VERSION) to docker registry"
 
+common:
+	yes | cp -rf ../common ./.common
+
 build: common
 ifdef REBUILD
 	@echo "REBUILDING $(NAME):$(VERSION)"

--- a/python3.4/Makefile
+++ b/python3.4/Makefile
@@ -20,6 +20,9 @@ help:
 	@echo "$(C_BG)make tag_latest$(C_OFF)         Tag $(NAME):$(VERSION) as :latest"
 	@echo "$(C_BG)make push$(C_OFF)               Push $(NAME):$(VERSION) to docker registry"
 
+common:
+	yes | cp -rf ../common ./.common
+
 build: common
 ifdef REBUILD
 	@echo "REBUILDING $(NAME):$(VERSION)"

--- a/python3.5-node6/Dockerfile
+++ b/python3.5-node6/Dockerfile
@@ -1,0 +1,59 @@
+FROM python:3.5.2
+
+MAINTAINER Thorgate, hi@thorgate.eu
+
+RUN apt-get update
+RUN apt-get install -y apt-transport-https
+RUN curl -sL add https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN echo "deb http://deb.nodesource.com/node_6.x jessie main" > /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb-src http://deb.nodesource.com/node_6.x jessie main" >> /etc/apt/sources.list.d/nodesource.list
+RUN echo "Package: *" > /etc/apt/preferences.d/deb_nodesource_com_node.pref
+RUN echo "Pin: release o=Node Source" >> /etc/apt/preferences.d/deb_nodesource_com_node.pref
+RUN echo "Pin-Priority: 500" >> /etc/apt/preferences.d/deb_nodesource_com_node.pref
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y  \
+    build-essential \
+    ca-certificates \
+    gcc \
+    gettext \
+    git \
+    libffi-dev \
+    libpq-dev \
+    locales \
+    make \
+    mercurial \
+    nodejs \
+    pkg-config \
+    ssh \
+    wget \
+    && apt-get autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+RUN sed -i -e 's/# et_EE UTF-8/et_EE UTF-8/' /etc/locale.gen
+RUN sed -i -e 's/# et_EE.UTF-8 UTF-8/et_EE.UTF-8 UTF-8/' /etc/locale.gen
+RUN sed -i -e 's/# ru_RU UTF-8/ru_RU UTF-8/' /etc/locale.gen
+RUN sed -i -e 's/# ru_RU.UTF-8 UTF-8/ru_RU.UTF-8 UTF-8/' /etc/locale.gen
+RUN locale-gen --purge en_US.UTF-8 et_EE et_EE.UTF-8 ru_RU ru_RU.UTF-8
+ENV DEBIAN_FRONTEND noninteractive
+RUN dpkg-reconfigure -f noninteractive locales
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# install requirements
+RUN apt-get update
+RUN apt-get install -y libzip-dev libxml2-dev libxslt1-dev curl
+RUN apt-get install -y libjpeg62 libjpeg62-turbo-dev zlib1g-dev
+RUN pip install --upgrade pip
+RUN pip install wheel
+
+# Copy pip config
+RUN ls -la
+COPY .common/pip.conf /root/.config/pip/pip.conf
+
+VOLUME /wheelhouse

--- a/python3.5-node6/Makefile
+++ b/python3.5-node6/Makefile
@@ -1,5 +1,5 @@
-NAME = thorgate/python3.4-node6
-VERSION = 1.2.0
+NAME = thorgate/python3.5-node6
+VERSION = 1.0.0
 
 # Configure make
 .PHONY: help common build tag_latest push release

--- a/python3.5-node6/README.md
+++ b/python3.5-node6/README.md
@@ -1,0 +1,11 @@
+# python3.5-node6
+
+- python3.5.2
+- nodejs 6.x
+
+# Updating
+
+1. Update version in Makefile
+2. Update the Dockerfile
+3. `make build`
+4. `make release`


### PR DESCRIPTION
Image based on python-3.5.2 (which is based on Debian), including Node v6.