### PR TITLE
Add Docker Compose base image for GitLab CI

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,0 +1,8 @@
+FROM docker:latest
+
+MAINTAINER Thorgate, hi@thorgate.eu
+
+RUN apk update
+RUN apk upgrade
+RUN apk add python3 python3-dev build-base
+RUN pip3 install docker-compose

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -1,0 +1,51 @@
+NAME = thorgate/docker-compose
+VERSION = 0.1
+
+# Configure make
+.PHONY: help common build tag_latest push release
+.DEFAULT_GOAL := help
+.SHELL = '/bin/bash'
+
+# Colors
+C_BG = \033[32;01m
+C_BY = \033[33;01m
+C_OFF = \033[0m
+
+# Goals
+help:
+	@echo "Goals"
+	@echo "===================================================================================================="
+	@echo "$(C_BG)make release$(C_OFF)            Run build->tag_latest->push"
+	@echo "$(C_BG)make build$(C_OFF)              Build $(NAME):$(VERSION)"
+	@echo "$(C_BG)make tag_latest$(C_OFF)         Tag $(NAME):$(VERSION) as :latest"
+	@echo "$(C_BG)make push$(C_OFF)               Push $(NAME):$(VERSION) to docker registry"
+
+common:
+	yes | cp -rf ../common ./.common
+
+build: common
+ifdef REBUILD
+	@echo "REBUILDING $(NAME):$(VERSION)"
+	docker build -t $(NAME):$(VERSION) .
+else
+	@if docker images $(NAME) | awk '{ print $2 }' | grep -q -F $(VERSION); then echo "$(NAME) version $(VERSION) is already built. Use 'REBUILD=1 make build' to rebuild"; false; fi
+	docker build -t $(NAME):$(VERSION) .
+endif
+
+tag_latest:
+	@echo "$(C_BY)Tag $(NAME):$(VERSION) as :latest?$(C_OFF)"
+	@read -p "[y/N] " TAG_LATEST; \
+	if [ $$TAG_LATEST != "y" ] && [ $$TAG_LATEST != "Y" ]; then \
+		echo 'not tagging'; \
+	else \
+		docker tag $(NAME):$(VERSION) $(NAME):latest; \
+	fi
+
+push:
+	@if ! docker images $(NAME) | awk '{ print $2 }' | grep -q -F $(VERSION); then echo "$(NAME) version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	docker push $(NAME)
+
+release:
+	@if ! docker images $(NAME) | awk '{ print $2 }' | grep -q -F $(VERSION); then $(MAKE) build; fi
+	$(MAKE) tag_latest
+	$(MAKE) push

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,11 @@
+# Docker Compose base image for GitLab CI
+
+- docker:latest
+- docker-compose
+
+# Updating
+
+1. Update version in Makefile
+2. Update the Dockerfile
+3. `make build`
+4. `make release`


### PR DESCRIPTION
A simple base image with Docker Compose to use in our CI builds, removing the need to run these commands during every build for every project.